### PR TITLE
Modify the method for determining JRE version

### DIFF
--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -5,6 +5,7 @@
 <%@ page import="java.util.HashMap"%>
 <%@ page import="java.util.Locale"%>
 <%@ page import="java.util.Map"%>
+<%@ page import="java.util.regex.*"%>
 <%@ page import="org.jivesoftware.util.*" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -29,9 +30,8 @@
     // Check for JRE 1.8
     try {
         String version = System.getProperty("java.version");
-        int pos = version.indexOf('.');
-        pos = version.indexOf('.', pos+1);
-        jreVersionCompatible = Double.parseDouble ( version.substring ( 0, pos)) >= 11;
+        Matcher matcher = Pattern.compile("^\\d+(\\.\\d+)?").matcher(version);
+        boolean jreVersionCompatible = matcher.find() && Double.parseDouble(matcher.group(0)) >= 11;
     }
     catch (Throwable t) {}
     // Check for Servlet 2.3:


### PR DESCRIPTION
Previously, the method assumed that the format of the JRE version is: `major.minor.build`. 
However, for `openjdk 21`, the value of `System.getProperty("java.version")` is `21`. 

This caused the previous method of determination to fail, resulting in the following error message:
> Error: Can not proceed with Openfire Setup.
Your current installation fails to meet minimum server requirements - please see the checklist below: ✗ At least JRE 11
✓ Servlet 2.3 Support
✓ JSP 1.2 Support
✓ Openfire Classes
✓ Openfire Home found (/usr/local/openfire)

Therefore, the method was modified to extract the significant digits using the regular expression `^\d+(\.\d+)?` for version comparison. 

The modified method for determination was tested in the following environments:
| **JRE Version** | 21 | 17.0.1 | 11.0.4 | 10.0.1 | 9.0.1 | 1.8.0_66 | 
|:---:|:---|:---|:---|:---|:---|:---|
| **matcher.group(0)** | 21 | 17.0 | 11.0 | 10.0 | 9.0 | 1.8 | 
| **jreVersionCompatible** | true | true | true | false | false | false |