### PR TITLE
Fixing the redefinition error of `jreVersionCompatible`

### DIFF
--- a/xmppserver/src/main/webapp/setup/index.jsp
+++ b/xmppserver/src/main/webapp/setup/index.jsp
@@ -31,7 +31,7 @@
     try {
         String version = System.getProperty("java.version");
         Matcher matcher = Pattern.compile("^\\d+(\\.\\d+)?").matcher(version);
-        boolean jreVersionCompatible = matcher.find() && Double.parseDouble(matcher.group(0)) >= 11;
+        jreVersionCompatible = matcher.find() && Double.parseDouble(matcher.group(0)) >= 11;
     }
     catch (Throwable t) {}
     // Check for Servlet 2.3:


### PR DESCRIPTION
Should have used the outer variable `jreVersionCompatible`, but mistakenly defined a new one inside the try block. Correcting the mistake.